### PR TITLE
Add support for 'list'

### DIFF
--- a/colors/basic-dark.vim
+++ b/colors/basic-dark.vim
@@ -23,6 +23,7 @@ let s:blue = "6699cc"
 let s:purple = "ce93d8"
 let s:window = "37474f"
 let s:grey = "b0bec5"
+let s:lcs = "425761"
 
 if !has("gui_running")
     let s:background = "202020"
@@ -247,7 +248,8 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
     " Vim Highlighting
     call <SID>X("Normal", s:foreground, s:background, "none")
     call <SID>X("LineNr", s:grey, "", "none")
-    call <SID>X("NonText", s:foreground, "", "none")
+    call <SID>X("NonText", s:lcs, "", "none")
+    call <SID>X("Whitespace", s:lcs, "", "none")
     call <SID>X("SpecialKey", s:blue, "", "none")
     call <SID>X("Search", s:foreground, s:selection, "none")
     call <SID>X("TabLine", s:foreground, s:background, "reverse")

--- a/colors/basic-light.vim
+++ b/colors/basic-light.vim
@@ -27,6 +27,7 @@ let s:diff_red = "ff9999"
 let s:diff_green = "99ff99"
 let s:diff_yellow = "ffff99"
 let s:diff_aqua = "9999ff"
+let s:lcs = "C7BFBB"
 
 
 set background=light
@@ -246,7 +247,8 @@ if has("gui_running") || &t_Co == 88 || &t_Co == 256
     " Vim Highlighting
     call <SID>X("Normal", s:foreground, s:background, "none")
     call <SID>X("LineNr", s:comment, "", "none")
-    call <SID>X("NonText", s:foreground, "", "none")
+    call <SID>X("NonText", s:lcs, "", "none")
+    call <SID>X("Whitespace", s:lcs, "", "none")
     call <SID>X("SpecialKey", s:blue, "", "none")
     call <SID>X("Search", s:foreground, s:selection, "none")
     call <SID>X("TabLine", s:foreground, s:background, "reverse")


### PR DESCRIPTION
If 'list' is enabled, the characters used to represent whitespace look
like text. This sets them to a low contrast colour, such that they are
visible but don't get in the way.